### PR TITLE
MNT: Fix examples with matplotlib 2.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@
  dependencies:
    - python=3
    - numpy=1.11
-   - matplotlib!=2.1
+   - matplotlib
    - cartopy
    - jupyter
    - metpy

--- a/examples/Satellite_Example.py
+++ b/examples/Satellite_Example.py
@@ -100,7 +100,7 @@ state_boundaries = cfeat.NaturalEarthFeature(category='cultural',
                                              scale='50m', facecolor='none')
 
 ax.add_feature(state_boundaries, edgecolor='black', linestyle=':')
-ax.add_feature(cfeat.BORDERS, linewidth='2', edgecolor='black')
+ax.add_feature(cfeat.BORDERS, linewidth=2, edgecolor='black')
 
 # Plot the image with our colormapping choices
 wv_norm, wv_cmap = registry.get_with_steps('WVCIMSS', 0, 1)


### PR DESCRIPTION
Passing linewidth as a string should never have worked, but is
definitely an error with matplotlib 2.1.