### PR TITLE
Fix dy values

### DIFF
--- a/examples/Ageostrophic_Wind_Example.py
+++ b/examples/Ageostrophic_Wind_Example.py
@@ -84,7 +84,6 @@ height = ndimage.gaussian_filter(height, sigma=1.5, order=0)
 # grid spacing, converting lon/lat spacing to Cartesian
 f = mpcalc.coriolis_parameter(np.deg2rad(lat_2d)).to('1/s')
 dx, dy = mpcalc.lat_lon_grid_deltas(lon_2d, lat_2d)
-dy *= -1
 
 # In MetPy 0.5, geostrophic_wind() assumes the order of the dimensions is (X, Y),
 # so we need to transpose from the input data, which are ordered lat (y), lon (x).


### PR DESCRIPTION
Looking through the examples I noticed we no longer had geostrophic winds. The error resulted from the change from `lat_lon_grid_spacing` to `lat_lon_grid_deltas`. The 'deltas' version obtains the appropriate sign, so this PR simply remove the now unnecessary `dy *= -1` line.