### PR TITLE
Updated instructions for using conda environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,18 +32,18 @@ conda env create -f environment.yml
 
 ### From a Unix command line (e.g., OS X terminal)
 If your default shell is NOT bash, first type `bash`.
-To activate or switch to a conda environment, you can `source activate
+To activate or switch to a conda environment, you can `conda activate
 <environment>`. For example,
 
 ```sh
-source activate gallery
+conda activate gallery
 ```
 
 To switch and/or deactivate environments:
 
 ```sh
-source deactivate
-source activate <environment>
+conda deactivate
+conda activate <environment>
 ```
 
 ### From a Windows command line (e.g., cmd.exe)

--- a/website/index.rst
+++ b/website/index.rst
@@ -86,6 +86,8 @@ Running an example
 * If you are running the example as a script, run `python the_script_name.py`
 * If you are running the example as a notebook start the jupyter environment
   with `jupyter notebook` or `jupyter lab`
+* When you want to return to the root environment, run the command `conda deactivate`
+  to exit the `gallery` environment.
 
 Contact Us
 ----------


### PR DESCRIPTION
A recent release of conda changed the syntax from "source activate" to "conda activate". Also added a line to index.rst explaining how to deactivate an environment. This also addresses and completes #98, which was almost completely addressed previously. 