### PR TITLE
fix Precip url

### DIFF
--- a/examples/Precipitation_Map.py
+++ b/examples/Precipitation_Map.py
@@ -24,7 +24,7 @@ from netCDF4 import Dataset
 ###############################
 # Download the data from the National Weather Service.
 dt = datetime.utcnow() - timedelta(days=1)  # This should always be available
-url = 'http://water.weather.gov/precip/downloads/{dt:%Y/%m/%d}/nws_precip_1day_'\
+url = 'https://water.weather.gov/precip/downloads/{dt:%Y/%m/%d}/nws_precip_1day_'\
       '{dt:%Y%m%d}_conus.nc'.format(dt=dt)
 data = urlopen(url).read()
 nc = Dataset('', memory=data)


### PR DESCRIPTION
Travis is throwing an error with the Precipitation_Map example due to a malformed URL. It appears that there is not an 's' in https, so trying to fix the URL. I can't reproduce this error locally.